### PR TITLE
Add regex option to readTimeSeries

### DIFF
--- a/R/readTimeseries.R
+++ b/R/readTimeseries.R
@@ -6,6 +6,7 @@
 #' R time series object of class 'ts' is built and returned. Irregular time series return zoo objects.
 #' 
 #' @author Matthias Bannert, Gabriel Bucur
+#'
 #' @param series character vector of time series keys
 #' @param con a PostgreSQL connection object
 #' @param valid_on character date string on which the series should be valid. Defaults to NULL. Only needed when different vintages of a time series are stored.  
@@ -14,7 +15,9 @@
 #' @param tbl_vintages character table name of the relation that holds time series vintages
 #' @param schema character SQL schema name. Defaults to timeseries.
 #' @param pkg_for_irreg character name of package for irregular series. xts or zoo, defaults to xts.
+#' @param regex If set to TRUE, \code{readTimeSeries} will get all time series which keys matching the pattern given in series
 #' @param chunksize numeric value of threshold at which input vector should be processed in chunks. defaults to 70000.
+#'
 #' @importFrom DBI dbGetQuery
 #' @importFrom jsonlite fromJSON
 #' @export

--- a/R/readTimeseries.R
+++ b/R/readTimeseries.R
@@ -25,7 +25,25 @@ readTimeSeries <- function(series, con,
                            schema = "timeseries",
                            env = NULL,
                            pkg_for_irreg = "xts",
-                           chunksize = 10000){
+                           chunksize = 10000,
+                           regex = FALSE){
+  
+  if(regex) {
+    if(length(series) > 1) {
+      stop("Only supports a single expression in series!")
+    }
+    
+    pattern <- series
+    
+    match_query <- sprintf("SELECT ts_key FROM %s.timeseries_main WHERE ts_key ~ '%s'",
+                         schema, pattern)
+    series <- dbGetQuery(con, match_query)$ts_key
+    
+    if(length(series) == 0) {
+      stop(sprintf("No series found matching '%s'!", pattern))
+    }
+  }
+  
   useries <- unique(series)
   if(length(useries) != length(series)){
     warning("Input vector contains non-unique keys, stripped duplicates.")


### PR DESCRIPTION
Would it be better to have a separate pattern param and ignore
series if regex == TRUE?

Relates to #27