### PR TITLE
Fix issue causing years with months 2-13

### DIFF
--- a/R/indexToDate.R
+++ b/R/indexToDate.R
@@ -12,7 +12,7 @@
 #' @export
 indexToDate <- function (x, as.string = FALSE) 
 {
-  years <- floor(x)
+  years <- floor(x + 1/24)
   months <- floor(12*(x - years + 1/24)) + 1
   # No support for days currently
   # datestr <- paste(years, months, 1, sep = "-")


### PR DESCRIPTION
In indexToDate, line 15, floor(zoolike-index) is used to determine
the year of the index. Due to numerical imprecisions, the year 1988 e.g.
may be internally represented as 1987.9999...7726, leading to the wrong
result when flooring. This in turn led to said year having
a 13th month and the next lacking the first.