### PR TITLE
Check for duplicates in storeTimeSeries

### DIFF
--- a/R/storeTimeSeries.R
+++ b/R/storeTimeSeries.R
@@ -42,6 +42,18 @@ storeTimeSeries <- function(con,
     series <- char_series
   }
   
+  unames <- unique(names(li))
+  if(length(unames) < length(li)) {
+    warning("Duplicate names in list, using only the first of each!");
+    li <- li[unames]
+  }
+  
+  useries <- unique(series)
+  if(length(useries) < length(series)) {
+    warning("Duplicate elements in series, using each only once!");
+    series <- useries
+  }
+  
   # subset 
   li <- li[series]
   # avoid overwrite totally, 


### PR DESCRIPTION
storeTimeSeries checks for duplicate names in li and removes them,
then for duplicate elements in series and removes them.
Each case results in a warning.