### PR TITLE
check for duplicate id time entries when storing dt

### DIFF
--- a/R/store_time_series.R
+++ b/R/store_time_series.R
@@ -24,6 +24,7 @@ store_time_series <- function(con,
 }
 
 #'@export
+# TODO: Add a test for this
 store_time_series.list <- function(con,
                                    tsl,
                                    access = NA,

--- a/R/store_time_series.R
+++ b/R/store_time_series.R
@@ -52,6 +52,10 @@ store_time_series.tslist <- function(con,
     return(list())
   }
 
+  if(any(duplicated(names(tsl)))) {
+    stop("Time series list contains duplicate keys.")
+  }
+
   # SANITY CHECK ##############
   keep <- sapply(tsl, function(x) inherits(x,c("ts","zoo","xts")))
   dontkeep <- !keep

--- a/R/store_time_series.R
+++ b/R/store_time_series.R
@@ -96,6 +96,10 @@ store_time_series.data.table <- function(con,
     stop("\"value\" must be numeric.")
   }
 
+  if(anyDuplicated(dt, by = c("id", "time")) > 0) {
+    stop("data.table contains duplicated (id, time) pairs. Are there duplicate series?")
+  }
+
   store_records(con,
                 to_ts_json(dt),
                 access,

--- a/tests/testthat/test_store_time_series.R
+++ b/tests/testthat/test_store_time_series.R
@@ -70,6 +70,14 @@ test_that("it handles non-ts-likes", {
     })
 })
 
+test_that("It handles duplicate names", {
+  tsl_local <- tsl
+  names(tsl_local) <- c("tsa", "tsa")
+  expect_error(
+    store_time_series("con", tsl_local, "release", "access"),
+    "duplicate keys"
+  )
+})
 
 # # store time series from data.table  ##########################
 

--- a/tests/testthat/test_store_time_series.R
+++ b/tests/testthat/test_store_time_series.R
@@ -7,7 +7,7 @@ tsl <- list(
 class(tsl) <- c("tslist", "list")
 
 dt <- data.table(
-  id = c("ts1", "ts2"),
+  id = rep(c("ts1", "ts2"), each = 2),
   time = seq(as.Date("2019-01-01"), length.out = 2, by = "1 month"),
   value = 1:4
 )
@@ -140,5 +140,18 @@ test_that("it complains about character-ts in dt", {
   expect_error(
     store_time_series("con", char_dt, "release", "access"),
     "numeric"
+  )
+})
+
+test_that("id complains about duplicate series in dt", {
+  dup_dt <- data.table(
+    id = "dupli_mac_dupleton",
+    time = rep(seq(Sys.Date(), length.out = 13, by = "3 month"), each = 2),
+    value = pi
+  )
+
+  expect_error(
+    store_time_series("con", dup_dt, "release", "access"),
+    "duplicated"
   )
 })


### PR DESCRIPTION
fixes #118 as this is all that can be really done for integrity

I opted for error instead of warning as in data.tables duplicates may be indicative of deeper issues.

simply skipping one of the duplicates may not be the best option for tsl either really.