### PR TITLE
remove check check if all elements are ts like from db_ts_store.list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: timeseriesdb
 Type: Package
-Version: 1.0.0-1.1.0
+Version: 1.0.0-1.1.1
 Title: A Time Series Database for Official Statistics with R and PostgreSQL
 Description: Archive and manage times series data from official statistics. The 'timeseriesdb' package was designed to manage a large catalog of time series from official statistics which are typically published on a monthly, quarterly or yearly basis. Thus timeseriesdb is optimized to handle updates caused by data revision as well as elaborate, multi-lingual meta information. 
 Authors@R: as.person(c(

--- a/R/store_time_series.R
+++ b/R/store_time_series.R
@@ -56,10 +56,6 @@ db_ts_store.list <- function(con,
                              release_date = NULL,
                              pre_release_access = NULL,
                              schema = "timeseries"){
-
-  is_tsl <- sapply(x, function(y) inherits(y, c("ts","zoo","xts")))
-
-  x <- x[is_tsl]
   class(x) <- c("tslist", "tsl")
   db_ts_store(con, x,
               access = access,


### PR DESCRIPTION
* db_ts_store.tslist already has such a check
* if an empty list is passed to the .list variant this causes an error
because sapply returns a list(), not a vector. the .tslist method avoids
this by first checking if the list is empty

kof-internal note:
this should fix the intermittent kofcast-dag failures