### PR TITLE
Update installation_guide.Rmd

### DIFF
--- a/vignettes/installation_guide.Rmd
+++ b/vignettes/installation_guide.Rmd
@@ -96,6 +96,7 @@ GRANT timeseries_access_main to timeseries_access_restricted;
 CREATE ROLE timeseries_admin NOLOGIN;
 GRANT timeseries_writer TO timeseries_admin;
 GRANT timeseries_access_restricted TO timeseries_admin;
+GRANT ALL ON SCHEMA timeseries TO timeseries_admin;
 
 ```
 


### PR DESCRIPTION
Without granting the permissions to `timeseries_admin`, the setup in `install_timeseriesdb()`  cannot complete.