### PR TITLE
fix type error

### DIFF
--- a/R/read_time_series.R
+++ b/R/read_time_series.R
@@ -26,7 +26,7 @@ db_ts_read <- function(con,
 
   # RPostgres plays nicer with NA than with NULL
   if(is.null(valid_on)) {
-    valid_on <- NA
+    valid_on <- as.Date(NA)
   }
 
   keys_unique <- unique(ts_keys)


### PR DESCRIPTION
Without this type change, `dbQuoteLiteral` in row 46 returns the `NA` as `NULL::bool`, which doesn't match the DATE type required by the `ts_read_raw` function (the one on row 173 of `create_functions_ts.sql`.